### PR TITLE
Add Google search scraping flow and restart-search-all endpoint

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -296,7 +296,8 @@ class SearchClient:
     async def search_single_term_all_regions(self, term: str, brand: str, entry_id: int) -> List[Dict]:
         async with self.semaphore:
             process_info = psutil.Process()
-            search_url_google = f"https://www.google.com/search?q={urllib.parse.quote(term)}&tbm=isch"
+            quoted_term = f'"{term}"'
+            search_url_google = f"https://www.google.com/search?q={urllib.parse.quote(quoted_term)}&tbm=isch"
             current_session = await self._get_session()
             results = []
 

--- a/app/api.py
+++ b/app/api.py
@@ -38,8 +38,16 @@ from tenacity import (RetryError, before_sleep_log, retry,
 from ai_utils import batch_vision_reason
 from common import (fetch_brand_rules, generate_search_variations,
                     preprocess_sku)
-from config import (BRAND_RULES_URL, DATAPROXY_API_KEY, RABBITMQ_URL,ROAMINGPROXY_API_URL, ROAMINGPROXY_API_KEY,
-                    SEARCH_PROXY_API_URL) # VERSION removed, will define locally
+from config import (
+    BRAND_RULES_URL,
+    DATAPROXY_API_KEY,
+    RABBITMQ_URL,
+    ROAMINGPROXY_API_URL,
+    ROAMINGPROXY_API_KEY,
+    SEARCH_PROXY_API_URL,
+    PROXY_STRATEGY,
+    PROXY_REGIONS,
+)  # VERSION removed, will define locally
 from database_config import async_engine
 from db_utils import (enqueue_db_update, fetch_last_valid_entry,
                       get_images_excel_db, get_send_to_email,
@@ -216,7 +224,13 @@ class ProxyType(Enum):
     ROAMINGPROXY = "roamingproxy"
 
 class SearchClient:
-    def __init__(self, logger: logging.Logger, max_concurrency: int = 10, proxy_strategy: str = "round_robin"):
+    def __init__(
+        self,
+        logger: logging.Logger,
+        max_concurrency: int = 10,
+        proxy_strategy: str = "round_robin",
+        regions: Optional[List[str]] = None,
+    ):
         self.logger = logger
         self.semaphore = asyncio.Semaphore(max_concurrency)
         self.proxy_strategy = proxy_strategy
@@ -241,7 +255,12 @@ class SearchClient:
             }
         }
         self._aiohttp_session: Optional[aiohttp.ClientSession] = None
-        self.regions = ['northamerica-northeast', 'us-east', 'us-central', 'us-west']
+        self.regions = regions if regions is not None else [
+            'northamerica-northeast',
+            'us-east',
+            'us-central',
+            'us-west',
+        ]
         self._request_counter = 0  # For round-robin strategy
 
     async def _get_session(self) -> aiohttp.ClientSession:
@@ -474,7 +493,11 @@ async def orchestrate_entry_search(
 
     all_valid_results_collected: List[Dict] = []
     variation_type_priority = ["default"]
-    search_client = SearchClient(logger=logger)
+    search_client = SearchClient(
+        logger=logger,
+        proxy_strategy=PROXY_STRATEGY,
+        regions=PROXY_REGIONS,
+    )
     try:
         for variation_type in variation_type_priority:
             terms_for_type = search_variations_map.get(variation_type, [])

--- a/app/api.py
+++ b/app/api.py
@@ -47,7 +47,7 @@ from db_utils import (enqueue_db_update, fetch_last_valid_entry,
                       update_file_location_complete, update_initial_sort_order,
                       update_log_url_in_db)
 from email_utils import send_message_email, send_email
-from icon_image_lib.google_parser import process_search_result
+from icon_image_lib.google_parser import process_search_result, process_search_page
 from logging_config import setup_job_logger
 from rabbitmq_producer import RabbitMQProducer
 from s3_utils import upload_file_to_space
@@ -336,6 +336,24 @@ class SearchClient:
                                         html_bytes = html_content_from_api.encode('utf-8') if isinstance(html_content_from_api, str) else str(html_content_from_api).encode('utf-8')
                                         formatted_results_df = process_search_result(html_bytes, entry_id, self.logger)
                                         if not formatted_results_df.empty:
+                                            try:
+                                                general_search_url = f"https://www.google.com/search?q={urllib.parse.quote(term)}"
+                                                async with current_session.post(
+                                                    fallback_endpoint,
+                                                    json={"url": general_search_url},
+                                                    headers=self.proxies[fallback_proxy_type]["headers"]
+                                                ) as search_page_response:
+                                                    search_page_response.raise_for_status()
+                                                    search_page_json = await search_page_response.json()
+                                                    search_page_html = search_page_json.get("result")
+                                                    if search_page_html:
+                                                        search_html_bytes = search_page_html.encode('utf-8') if isinstance(search_page_html, str) else str(search_page_html).encode('utf-8')
+                                                        process_search_page(search_html_bytes, entry_id, self.logger)
+                                            except Exception as e_search:
+                                                self.logger.warning(
+                                                    f"PID {process_info.pid}: Failed to fetch search page for term='{term}' in region {region_name} via {fallback_proxy_type.value}: {e_search}",
+                                                    exc_info=True
+                                                )
                                             results = [
                                                 {
                                                     "EntryID": entry_id,
@@ -373,6 +391,24 @@ class SearchClient:
                             html_bytes = html_content_from_api.encode('utf-8') if isinstance(html_content_from_api, str) else str(html_content_from_api).encode('utf-8')
                             formatted_results_df = process_search_result(html_bytes, entry_id, self.logger)
                             if not formatted_results_df.empty:
+                                try:
+                                    general_search_url = f"https://www.google.com/search?q={urllib.parse.quote(term)}"
+                                    async with current_session.post(
+                                        current_fetch_endpoint,
+                                        json={"url": general_search_url},
+                                        headers=proxy_config["headers"]
+                                    ) as search_page_response:
+                                        search_page_response.raise_for_status()
+                                        search_page_json = await search_page_response.json()
+                                        search_page_html = search_page_json.get("result")
+                                        if search_page_html:
+                                            search_html_bytes = search_page_html.encode('utf-8') if isinstance(search_page_html, str) else str(search_page_html).encode('utf-8')
+                                            process_search_page(search_html_bytes, entry_id, self.logger)
+                                except Exception as e_search:
+                                    self.logger.warning(
+                                        f"PID {process_info.pid}: Failed to fetch search page for term='{term}' in region {region_name} via {proxy_type.value}: {e_search}",
+                                        exc_info=True
+                                    )
                                 self.logger.info(
                                     f"PID {process_info.pid}: Successfully found {len(formatted_results_df)} results for term='{term}' "
                                     f"in region {region_name} via {proxy_type.value}."
@@ -757,6 +793,7 @@ async def process_restart_batch(
     logger: logging.Logger = default_logger,
     background_tasks: Optional[BackgroundTasks] = None,
     num_workers: int = 4,
+    process_all_entries: bool = False,
 ) -> Dict[str, Any]:
     current_log_filename = "unknown_log_file.log"  # Placeholder
     if logger.handlers and hasattr(logger.handlers[0], "baseFilename"):
@@ -860,34 +897,26 @@ async def process_restart_batch(
     entries_to_process_list: List[Tuple] = []
     try:
         async with async_engine.connect() as db_conn_fetch:
-            sql_fetch_entries = text(
-                """
-                SELECT r.{SCRAPER_RECORDS_PK_COLUMN}, r.{SCRAPER_RECORDS_PRODUCT_MODEL_COLUMN}, 
-                    r.{SCRAPER_RECORDS_PRODUCT_BRAND_COLUMN}, r.{SCRAPER_RECORDS_PRODUCT_COLOR_COLUMN}, 
-                    r.{SCRAPER_RECORDS_PRODUCT_CATEGORY_COLUMN}
-                FROM {SCRAPER_RECORDS_TABLE_NAME} r
-                WHERE r.{SCRAPER_RECORDS_FILE_ID_FK_COLUMN} = :fid
-                AND r.{SCRAPER_RECORDS_PRODUCT_MODEL_COLUMN} IS NOT NULL 
-                AND r.{SCRAPER_RECORDS_PRODUCT_MODEL_COLUMN} <> ''
+            not_exists_clause = "" if process_all_entries else f"""
                 AND NOT EXISTS (
-                    SELECT 1 
-                    FROM {IMAGE_SCRAPER_RESULT_TABLE_NAME} res 
+                    SELECT 1
+                    FROM {IMAGE_SCRAPER_RESULT_TABLE_NAME} res
                     WHERE res.{IMAGE_SCRAPER_RESULT_ENTRY_ID_FK_COLUMN} = r.{SCRAPER_RECORDS_PK_COLUMN}
                         AND res.{IMAGE_SCRAPER_RESULT_SORT_ORDER_COLUMN} = 1
                 )
+            """
+            sql_fetch_entries = text(
+                f"""
+                SELECT r.{SCRAPER_RECORDS_PK_COLUMN}, r.{SCRAPER_RECORDS_PRODUCT_MODEL_COLUMN},
+                    r.{SCRAPER_RECORDS_PRODUCT_BRAND_COLUMN}, r.{SCRAPER_RECORDS_PRODUCT_COLOR_COLUMN},
+                    r.{SCRAPER_RECORDS_PRODUCT_CATEGORY_COLUMN}
+                FROM {SCRAPER_RECORDS_TABLE_NAME} r
+                WHERE r.{SCRAPER_RECORDS_FILE_ID_FK_COLUMN} = :fid
+                AND r.{SCRAPER_RECORDS_PRODUCT_MODEL_COLUMN} IS NOT NULL
+                AND r.{SCRAPER_RECORDS_PRODUCT_MODEL_COLUMN} <> ''
+                {not_exists_clause}
                 ORDER BY r.{SCRAPER_RECORDS_PK_COLUMN};
-            """.format(
-                    SCRAPER_RECORDS_PK_COLUMN=SCRAPER_RECORDS_PK_COLUMN,
-                    SCRAPER_RECORDS_PRODUCT_MODEL_COLUMN=SCRAPER_RECORDS_PRODUCT_MODEL_COLUMN,
-                    SCRAPER_RECORDS_PRODUCT_BRAND_COLUMN=SCRAPER_RECORDS_PRODUCT_BRAND_COLUMN,
-                    SCRAPER_RECORDS_PRODUCT_COLOR_COLUMN=SCRAPER_RECORDS_PRODUCT_COLOR_COLUMN,
-                    SCRAPER_RECORDS_PRODUCT_CATEGORY_COLUMN=SCRAPER_RECORDS_PRODUCT_CATEGORY_COLUMN,
-                    SCRAPER_RECORDS_TABLE_NAME=SCRAPER_RECORDS_TABLE_NAME,
-                    SCRAPER_RECORDS_FILE_ID_FK_COLUMN=SCRAPER_RECORDS_FILE_ID_FK_COLUMN,
-                    IMAGE_SCRAPER_RESULT_TABLE_NAME=IMAGE_SCRAPER_RESULT_TABLE_NAME,
-                    IMAGE_SCRAPER_RESULT_ENTRY_ID_FK_COLUMN=IMAGE_SCRAPER_RESULT_ENTRY_ID_FK_COLUMN,
-                    IMAGE_SCRAPER_RESULT_SORT_ORDER_COLUMN=IMAGE_SCRAPER_RESULT_SORT_ORDER_COLUMN,
-                )
+                """
             )
             db_res_entries = await db_conn_fetch.execute(
                 sql_fetch_entries, {"fid": file_id_for_db}
@@ -895,7 +924,8 @@ async def process_restart_batch(
             entries_to_process_list = db_res_entries.fetchall()
             db_res_entries.close()
         logger.info(
-            f"FileID {file_id_for_db}: Fetched {len(entries_to_process_list)} entries that have no results with SortOrder = 1."
+            f"FileID {file_id_for_db}: Fetched {len(entries_to_process_list)} entries"
+            + (" (all entries)." if process_all_entries else " that have no results with SortOrder = 1.")
         )
     except SQLAlchemyError as db_exc_fetch:
         error_msg = f"Database error fetching entries for FileID {file_id_for_db}: {db_exc_fetch}"
@@ -913,7 +943,11 @@ async def process_restart_batch(
             "last_entry_id_processed": "0",
         }
     if not entries_to_process_list:
-        success_msg = f"No entries with positive SortOrder results found for FileID {file_id_for_db}."
+        success_msg = (
+            f"No entries found for FileID {file_id_for_db}."
+            if process_all_entries
+            else f"No entries with positive SortOrder results found for FileID {file_id_for_db}."
+        )
         logger.info(success_msg)
         log_url = await upload_log_file(
             file_id_db_str,
@@ -1581,7 +1615,7 @@ async def api_clear_ai_json(file_id: str, entry_ids: Optional[List[int]] = Query
 @router.post("/restart-job/{file_id}", tags=["Processing"], response_model=None)
 async def api_process_restart_job(
     file_id: str,
-    background_tasks: BackgroundTasks, 
+    background_tasks: BackgroundTasks,
     entry_id: Optional[int] = Query(None),
     use_all_variations: bool = Query(False),
     num_workers_hint: int = Query(4, ge=1, le=cpu_count() * 2),
@@ -1596,6 +1630,34 @@ async def api_process_restart_job(
     if job_result["status_code"] != 200:
         raise HTTPException(status_code=job_result["status_code"], detail=job_result["message"])
     return {"status_code": 200, "message": f"Job restart for FileID '{file_id}' initiated.", "details": job_result.get("data"), "log_url": job_result.get("debug_info", {}).get("log_s3_url", "N/A")}
+
+
+@router.post("/restart-search-all/{file_id}", tags=["Processing"], response_model=None)
+async def api_restart_search_all(
+    file_id: str,
+    background_tasks: BackgroundTasks,
+    use_all_variations: bool = Query(False),
+    num_workers_hint: int = Query(4, ge=1, le=cpu_count() * 2),
+):
+    job_run_id = f"restart_search_all_{file_id}_{'allvars' if use_all_variations else 'stdvars'}_{num_workers_hint}w"
+    job_result = await run_job_with_logging(
+        job_func=process_restart_batch,
+        file_id_context=job_run_id,
+        file_id_db_str=file_id,
+        entry_id=None,
+        use_all_variations=use_all_variations,
+        background_tasks=background_tasks,
+        num_workers=num_workers_hint,
+        process_all_entries=True,
+    )
+    if job_result["status_code"] != 200:
+        raise HTTPException(status_code=job_result["status_code"], detail=job_result["message"])
+    return {
+        "status_code": 200,
+        "message": f"Restart search for all entries in FileID '{file_id}' initiated.",
+        "details": job_result.get("data"),
+        "log_url": job_result.get("debug_info", {}).get("log_s3_url", "N/A"),
+    }
 
 
 class TestableSearchResult(BaseModel):

--- a/app/config.py
+++ b/app/config.py
@@ -27,7 +27,6 @@ ROAMINGPROXY_API_KEY = config['roamingproxy_settings']['api_key']
 ROAMINGPROXY_API_URL = config['roamingproxy_settings']['api_url']
 PROXY_STRATEGY = config.get('proxy_strategy', 'round_robin')
 PROXY_REGIONS = config.get('proxy_regions', [
-    'northamerica-northeast',
     'us-east',
     'us-central',
     'us-west',

--- a/app/config.py
+++ b/app/config.py
@@ -26,6 +26,12 @@ SEARCH_PROXY_API_URL = config['dataproxy_settings']['api_url']
 ROAMINGPROXY_API_KEY = config['roamingproxy_settings']['api_key']
 ROAMINGPROXY_API_URL = config['roamingproxy_settings']['api_url']
 PROXY_STRATEGY = config.get('proxy_strategy', 'round_robin')
+PROXY_REGIONS = config.get('proxy_regions', [
+    'northamerica-northeast',
+    'us-east',
+    'us-central',
+    'us-west',
+])
 BRAND_RULES_URL = config['brand_settings']['brand_rules_url']
 AWS_ACCESS_KEY_ID = config['aws_settings']['access_key_id']
 AWS_SECRET_ACCESS_KEY = config['aws_settings']['secret_access_key']

--- a/app/icon_image_lib/google_parser.py
+++ b/app/icon_image_lib/google_parser.py
@@ -188,96 +188,92 @@ def get_original_images(html_bytes, logger=None):
     logger.debug(f"GetOriginal: URLs={len(main_image_urls)}, Desc={len(main_descriptions)}, Sources={len(main_source_urls)}, Thumbs={len(main_thumbs)}")
     return main_image_urls, main_descriptions, main_source_urls, main_thumbs
 
-def get_results_page_results(html_bytes, final_urls, final_descriptions, final_sources, final_thumbs, logger=None):
-    """Extract additional image data from results page HTML without base64."""
-    logger = logger or logging.getLogger(__name__) # Ensure logger
-    html_content = decode_html_bytes(html_bytes, logger)
+import logging
+from bs4 import BeautifulSoup
+from urllib.parse import unquote, urlparse
+import re
 
-    soup = BeautifulSoup(html_content, 'html.parser')
-    # Class names for Google search results can change, verify these if issues arise
-    result_divs = soup.find_all('div', class_='H8Rx8c') # This class seems to be for "Related images" or similar blocks
+def clean_source_url(raw_url: str) -> str:
+    """Clean a URL by decoding Unicode escape sequences and removing unnecessary characters."""
+    if not raw_url:
+        return ""
+    cleaned = unquote(raw_url)
+    cleaned = re.sub(r"\?.*$|#$", "", cleaned)
+    return cleaned.strip()
 
+def extract_true_url_from_wrapper(raw_url: str, logger: logging.Logger) -> str:
+    """Extract the true URL from Google's redirect wrapper URLs."""
+    if not raw_url:
+        return "No URL"
+    if raw_url.startswith("/url?"):
+        match = re.search(r"q=([^&]+)", raw_url)
+        if match:
+            return clean_source_url(match.group(1))
+    return clean_source_url(raw_url)
+
+def clean_image_url(url: str) -> str:
+    """Clean an image URL to ensure it's valid and direct."""
+    if not url or "data:image" in url:
+        return "No image URL"
+    if url.startswith("//"):
+        url = f"https:{url}"
+    elif url.startswith("/"):
+        url = f"https://www.google.com{url}"
+    return clean_source_url(url)
+
+def get_results_page_results(html_bytes: bytes, logger: logging.Logger = None) -> tuple[list, list, list, list]:
+    """
+    Extract organic search results from Google search results HTML.
+    
+    Args:
+        html_bytes: Raw HTML bytes of the Google search results page.
+        logger: Optional logger instance for debugging.
+    
+    Returns:
+        Tuple of (urls, titles, sources, thumbnails) as lists.
+    """
+    logger = logger or logging.getLogger(__name__)
+    try:
+        html_content = html_bytes.decode("utf-8", errors="ignore")
+    except Exception as e:
+        logger.error(f"Failed to decode HTML bytes: {e}")
+        return [], [], [], []
+
+    soup = BeautifulSoup(html_content, "html.parser")
+    final_urls, final_titles, final_sources, final_thumbs = [], [], [], []
+
+    result_divs = soup.find_all("div", class_="MjjYud")
     if not result_divs:
-        # Try another common class for image result items if H8Rx8c fails
-        result_divs = soup.find_all('div', class_='isv motiva_DRHBO') # Example: for individual image results
-        if not result_divs:
-            result_divs = soup.find_all('a', class_='isv-r') # Another common pattern for image items
-            if not result_divs:
-                 logger.warning("No primary result item divs (H8Rx8c, isv motiva_DRHBO, isv-r) found in additional results page")
-                 return final_urls, final_descriptions, final_sources, final_thumbs
+        logger.warning("No primary result divs (MjjYud) found, trying alternative selectors")
+        result_divs = soup.find_all("div", class_=lambda c: c and any(cls in c for cls in ["g", "tF2Cxc"]))
 
-    logger.info(f"Found {len(result_divs)} potential items in additional results page.")
+    logger.info(f"Found {len(result_divs)} potential result items.")
 
     for item_container in result_divs:
-        if len(final_urls) >= 100: # Overall cap
+        if len(final_urls) >= 100:
+            logger.debug("Reached result cap of 100, stopping.")
             break
 
-        # Thumbnail
-        # Common img tags: 'rg_i Q4LuWd', 'n3VNCb KAlRDb', 'YQ4gaf'
-        img_tag = item_container.find('img', class_=lambda c: c and any(cls in c for cls in ['rg_i', 'n3VNCb', 'YQ4gaf', 'gdOPf', 'uhHOwf', 'ez24Df']))
-        raw_thumb_url = None
-        if img_tag:
-            raw_thumb_url = img_tag.get('src') or img_tag.get('data-src')
-        
-        if not raw_thumb_url or 'data:image' in raw_thumb_url: # Skip base64
-            logger.debug("No valid thumbnail URL or base64 src in result item, skipping.")
-            continue
-        
-        thumb = clean_source_url(raw_thumb_url) # uXXXX decode for thumb
-        # Thumbnails are usually direct, no need for extract_true_url_from_wrapper or clean_image_url
+        link_tag = item_container.find("a", href=True)
+        raw_href = link_tag.get("href") if link_tag else None
+        url = extract_true_url_from_wrapper(raw_href, logger) if raw_href else "No URL"
+        final_urls.append(url)
+
+        title_tag = item_container.find("h3")
+        title = title_tag.get_text(strip=True) if title_tag else "No title"
+        final_titles.append(title)
+
+        source_tag = item_container.find("cite")
+        source = source_tag.get_text(strip=True).split(" › ")[0] if source_tag else urlparse(url).netloc or "No source"
+        final_sources.append(clean_source_url(source))
+
+        img_tag = item_container.find("img", class_=lambda c: c and any(cls in c for cls in ["rg_i", "n3VNCb", "YQ4gaf"]))
+        thumb_url = img_tag.get("src") or img_tag.get("data-src") if img_tag else None
+        thumb = clean_image_url(thumb_url) if thumb_url and "data:image" not in thumb_url else "No thumbnail"
         final_thumbs.append(thumb)
 
-        # Description
-        # Common description/title holders: 'bytUYc', 'VFACy kGQAp S2WUTe', 'mVDVAe'
-        desc_element = item_container.find(['div', 'span', 'a'], class_=lambda c: c and any(cls in c for cls in ['bytUYc', 'VFACy', 'mVDVAe', 'VwiC3b']))
-        description = desc_element.get_text(strip=True) if desc_element else 'No description'
-        final_descriptions.append(description)
-
-        # Source (often the domain name or page title linking to the source page)
-        # Common source holders: 'VuuXrf', 'SW5pqf', 'cite' with class 'qLRx3b'
-        source_element = item_container.find(['cite', 'div', 'span'], class_=lambda c: c and any(cls in c for cls in ['VuuXrf', 'SW5pqf', 'qLRx3b']))
-        raw_source_text = source_element.get_text(strip=True) if source_element else 'No source'
-        
-        # Process source text: clean uXXXX, then extract if it's a wrapper URL
-        # Check if it looks like a URL before trying to extract from wrapper
-        cleaned_source_text = clean_source_url(raw_source_text)
-        if cleaned_source_text.startswith(('http', '/', 'www.')):
-            source = extract_true_url_from_wrapper(cleaned_source_text, logger)
-        else:
-            source = cleaned_source_text # It's just text, not a URL
-        final_sources.append(source)
-
-        # Main Image URL (often found in a link wrapping the image or a data attribute)
-        # Common link tags: 'ایش zReHs', 'VFACy kGQAp S2WUTe', 'isv-r' (if item_container is this)
-        # Sometimes the link is the item_container itself if it's an <a> tag
-        link_tag = None
-        if item_container.name == 'a':
-            link_tag = item_container
-        else:
-            link_tag = item_container.find('a', class_=lambda c: c and any(cls in c for cls in ['zReHs', 'VFACy', 'isv-r']))
-
-        raw_href = link_tag.get('href') if link_tag and link_tag.get('href') else None
-        
-        # Alternative: Look for data-actualn3r (or similar) on img_tag for direct full image URL
-        if not raw_href and img_tag:
-             raw_href = img_tag.get('data-actualn3r') # This sometimes holds the direct image link
-
-        image_url_final = 'No image URL'
-        if raw_href:
-            url1 = clean_source_url(raw_href)
-            url2 = extract_true_url_from_wrapper(url1, logger)
-            image_url_final = clean_image_url(url2)
-        final_urls.append(image_url_final)
-
-    if len(final_urls) > 100: # Cap after processing
-        final_urls = final_urls[:100]
-        final_descriptions = final_descriptions[:100]
-        final_sources = final_sources[:100]
-        final_thumbs = final_thumbs[:100]
-        logger.debug("Capped total results from additional page processing at 100")
-
-    logger.debug(f"GetResultsPage: Total after append: URLs={len(final_urls)}")
-    return final_urls, final_descriptions, final_sources, final_thumbs
+    logger.debug(f"Parsed {len(final_urls)} results: URLs={len(final_urls)}, Titles={len(final_titles)}, Sources={len(final_sources)}, Thumbnails={len(final_thumbs)}")
+    return final_urls, final_titles, final_sources, final_thumbs
 
 
 def process_search_result(image_html_bytes, entry_id: int, logger=None) -> pd.DataFrame:
@@ -291,10 +287,6 @@ def process_search_result(image_html_bytes, entry_id: int, logger=None) -> pd.Da
     
     # Then, try to get images from structured HTML elements (if any, or as supplement)
     # Pass the *current* lists to be appended to.
-    final_urls, final_descriptions, final_sources, final_thumbs = get_results_page_results(
-        image_html_bytes, final_urls, final_descriptions, final_sources, final_thumbs, logger
-    )
-    
     # Ensure all lists have the same length before creating DataFrame
     all_lists = [final_urls, final_descriptions, final_sources, final_thumbs]
     if not all_lists: # Should not happen if functions return empty lists
@@ -321,12 +313,81 @@ def process_search_result(image_html_bytes, entry_id: int, logger=None) -> pd.Da
     logger.info(f"Processed EntryID {entry_id} with {len(df)} images (after potential truncation).")
     return df
 
-def process_search_page(html_bytes, entry_id: int, logger=None):
-    """Placeholder for processing standard Google search HTML results."""
+import logging
+from typing import List, Dict
+from bs4 import BeautifulSoup
+
+def process_search_page(html_bytes: bytes, entry_id: int, logger=None) -> List[Dict]:
+    """Process Google search page HTML to extract search results.
+
+    Args:
+        html_bytes (bytes): The HTML content of the search page in bytes.
+        entry_id (int): Identifier for the search entry.
+        logger (logging.Logger, optional): Logger instance for debugging and errors.
+
+    Returns:
+        List[Dict]: List of dictionaries containing extracted search result details.
+    """
     logger = logger or logging.getLogger(__name__)
+    
     if not html_bytes:
         logger.debug(f"EntryID {entry_id}: No search page HTML to process.")
         return []
-    logger.debug(f"EntryID {entry_id}: Received search page HTML ({len(html_bytes)} bytes).")
-    return []
-
+    
+    try:
+        logger.debug(f"EntryID {entry_id}: Processing search page HTML ({len(html_bytes)} bytes).")
+        
+        # Decode bytes to string, assuming UTF-8 encoding
+        html_content = html_bytes.decode('utf-8', errors='ignore')
+        
+        # Parse HTML with BeautifulSoup
+        soup = BeautifulSoup(html_content, 'html.parser')
+        
+        # Initialize results list
+        results = []
+        
+        # Find search result containers (based on common Google search result structure)
+        # Note: Google’s structure may change; this targets common classes as of 2025
+        result_divs = soup.find_all('div', class_='tF2Cxc')  # Common class for main results
+        
+        for idx, result in enumerate(result_divs):
+            try:
+                # Extract title
+                title_tag = result.find('h3')
+                title = title_tag.get_text(strip=True) if title_tag else "N/A"
+                
+                # Extract URL
+                link_tag = result.find('a')
+                url = link_tag.get('href') if link_tag else "placeholder://no-url"
+                
+                # Extract snippet/description
+                snippet_tag = result.find('div', class_='VwiC3b')  # Common class for snippets
+                snippet = snippet_tag.get_text(strip=True) if snippet_tag else "N/A"
+                
+                # Extract thumbnail URL if available
+                thumbnail_tag = result.find('img')
+                thumbnail_url = thumbnail_tag.get('src') if thumbnail_tag else url
+                
+                # Structure the result
+                result_data = {
+                    "EntryID": entry_id,
+                    "Title": title,
+                    "Url": url,
+                    "Description": snippet,
+                    "ThumbnailUrl": thumbnail_url
+                }
+                
+                results.append(result_data)
+                
+                logger.debug(f"EntryID {entry_id}: Extracted result {idx + 1} - Title: {title[:50]}...")
+                
+            except Exception as e:
+                logger.warning(f"EntryID {entry_id}: Failed to process result {idx + 1}: {e}")
+                continue
+        
+        logger.info(f"EntryID {entry_id}: Successfully extracted {len(results)} results.")
+        return results
+    
+    except Exception as e:
+        logger.error(f"EntryID {entry_id}: Failed to process search page HTML: {e}", exc_info=True)
+        return []

--- a/app/icon_image_lib/google_parser.py
+++ b/app/icon_image_lib/google_parser.py
@@ -320,3 +320,13 @@ def process_search_result(image_html_bytes, entry_id: int, logger=None) -> pd.Da
     
     logger.info(f"Processed EntryID {entry_id} with {len(df)} images (after potential truncation).")
     return df
+
+def process_search_page(html_bytes, entry_id: int, logger=None):
+    """Placeholder for processing standard Google search HTML results."""
+    logger = logger or logging.getLogger(__name__)
+    if not html_bytes:
+        logger.debug(f"EntryID {entry_id}: No search page HTML to process.")
+        return []
+    logger.debug(f"EntryID {entry_id}: Received search page HTML ({len(html_bytes)} bytes).")
+    return []
+

--- a/app/scraper_config.json
+++ b/app/scraper_config.json
@@ -13,6 +13,12 @@
   "proxy_settings": {
     "search_proxy_api_url": "https://api.thedataproxy.com/v2/proxy/fetch"
   },
+  "proxy_regions": [
+    "northamerica-northeast",
+    "us-east",
+    "us-central",
+    "us-west"
+  ],
   "brand_settings": {
     "brand_rules_url": "https://raw.githubusercontent.com/iconluxurygroup/legacy-icon-product-api/refs/heads/main/task_settings/brand_settings.json"
   },

--- a/app/scraper_config.json
+++ b/app/scraper_config.json
@@ -14,7 +14,6 @@
     "search_proxy_api_url": "https://api.thedataproxy.com/v2/proxy/fetch"
   },
   "proxy_regions": [
-    "northamerica-northeast",
     "us-east",
     "us-central",
     "us-west"


### PR DESCRIPTION
## Summary
- Fetch standard Google search page alongside image results and prepare placeholder parser hook
- Allow re-processing all entries by expanding restart batch logic and endpoint

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_6890facb7c848328841f5714762b27be