### PR TITLE
Parse and filter Google search results

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -55,7 +55,8 @@ from db_utils import (enqueue_db_update, fetch_last_valid_entry,
                       update_file_location_complete, update_initial_sort_order,
                       update_log_url_in_db)
 from email_utils import send_message_email, send_email
-from icon_image_lib.google_parser import process_search_result, process_search_page
+from icon_image_lib.google_parser import process_search_result
+from icon_image_lib.search_page_parser import get_results_page_results
 from logging_config import setup_job_logger
 from rabbitmq_producer import RabbitMQProducer
 from s3_utils import upload_file_to_space
@@ -367,8 +368,31 @@ class SearchClient:
                                                     search_page_json = await search_page_response.json()
                                                     search_page_html = search_page_json.get("result")
                                                     if search_page_html:
-                                                        search_html_bytes = search_page_html.encode('utf-8') if isinstance(search_page_html, str) else str(search_page_html).encode('utf-8')
-                                                        process_search_page(search_html_bytes, entry_id, self.logger)
+                                                        search_html_bytes = (
+                                                            search_page_html.encode("utf-8")
+                                                            if isinstance(search_page_html, str)
+                                                            else str(search_page_html).encode("utf-8")
+                                                        )
+                                                        urls, titles, sources, thumbs = get_results_page_results(
+                                                            search_html_bytes, self.logger
+                                                        )
+                                                        keywords = [brand, term]
+                                                        filtered_results = []
+                                                        for u, t, s, th in zip(urls, titles, sources, thumbs):
+                                                            combined = f"{u} {t}".lower()
+                                                            if all(
+                                                                k.lower() in combined for k in keywords if k
+                                                            ):
+                                                                try:
+                                                                    async with current_session.get(u) as nav_resp:
+                                                                        nav_resp.raise_for_status()
+                                                                        await nav_resp.text()
+                                                                except Exception as nav_e:
+                                                                    self.logger.warning(
+                                                                        f"PID {process_info.pid}: Failed to navigate to {u} for term='{term}' in region {region_name} via {fallback_proxy_type.value}: {nav_e}",
+                                                                        exc_info=True,
+                                                                    )
+                                                                filtered_results.append((u, t, s, th))
                                             except Exception as e_search:
                                                 self.logger.warning(
                                                     f"PID {process_info.pid}: Failed to fetch search page for term='{term}' in region {region_name} via {fallback_proxy_type.value}: {e_search}",
@@ -422,8 +446,29 @@ class SearchClient:
                                         search_page_json = await search_page_response.json()
                                         search_page_html = search_page_json.get("result")
                                         if search_page_html:
-                                            search_html_bytes = search_page_html.encode('utf-8') if isinstance(search_page_html, str) else str(search_page_html).encode('utf-8')
-                                            process_search_page(search_html_bytes, entry_id, self.logger)
+                                            search_html_bytes = (
+                                                search_page_html.encode("utf-8")
+                                                if isinstance(search_page_html, str)
+                                                else str(search_page_html).encode("utf-8")
+                                            )
+                                            urls, titles, sources, thumbs = get_results_page_results(
+                                                search_html_bytes, self.logger
+                                            )
+                                            keywords = [brand, term]
+                                            filtered_results = []
+                                            for u, t, s, th in zip(urls, titles, sources, thumbs):
+                                                combined = f"{u} {t}".lower()
+                                                if all(k.lower() in combined for k in keywords if k):
+                                                    try:
+                                                        async with current_session.get(u) as nav_resp:
+                                                            nav_resp.raise_for_status()
+                                                            await nav_resp.text()
+                                                    except Exception as nav_e:
+                                                        self.logger.warning(
+                                                            f"PID {process_info.pid}: Failed to navigate to {u} for term='{term}' in region {region_name} via {proxy_type.value}: {nav_e}",
+                                                            exc_info=True,
+                                                        )
+                                                    filtered_results.append((u, t, s, th))
                                 except Exception as e_search:
                                     self.logger.warning(
                                         f"PID {process_info.pid}: Failed to fetch search page for term='{term}' in region {region_name} via {proxy_type.value}: {e_search}",

--- a/app/icon_image_lib/google_parser.py
+++ b/app/icon_image_lib/google_parser.py
@@ -227,7 +227,7 @@ def get_results_page_results(html_bytes, final_urls, final_descriptions, final_s
 
         # Description
         # Updated description classes: 'VwiC3b' (from process_search_page), 's3v9rd', 'bytUYc'
-        desc_element = item_container.find(['div', 'span', 'a'], class_=lambda c: c and any(cls in c for cls in ['VwiC3b', 's3v9rd', 'bytUYc', 'mVDVAe']))
+        desc_element = item_container.find(['div', 'span', 'a'], class_=lambda c: c and any(cls in c for cls in ['VwiC3b', 's3v9rd', 'bytUYc', 'mVDVAe','MjjYud']))
         description = desc_element.get_text(strip=True) if desc_element else 'No description'
         final_descriptions.append(description)
 

--- a/app/icon_image_lib/google_parser.py
+++ b/app/icon_image_lib/google_parser.py
@@ -321,12 +321,82 @@ def process_search_result(image_html_bytes, entry_id: int, logger=None) -> pd.Da
     logger.info(f"Processed EntryID {entry_id} with {len(df)} images (after potential truncation).")
     return df
 
-def process_search_page(html_bytes, entry_id: int, logger=None):
-    """Placeholder for processing standard Google search HTML results."""
+import logging
+from typing import List, Dict
+from bs4 import BeautifulSoup
+
+def process_search_page(html_bytes: bytes, entry_id: int, logger=None) -> List[Dict]:
+    """Process Google search page HTML to extract search results.
+
+    Args:
+        html_bytes (bytes): The HTML content of the search page in bytes.
+        entry_id (int): Identifier for the search entry.
+        logger (logging.Logger, optional): Logger instance for debugging and errors.
+
+    Returns:
+        List[Dict]: List of dictionaries containing extracted search result details.
+    """
     logger = logger or logging.getLogger(__name__)
+    
     if not html_bytes:
         logger.debug(f"EntryID {entry_id}: No search page HTML to process.")
         return []
-    logger.debug(f"EntryID {entry_id}: Received search page HTML ({len(html_bytes)} bytes).")
-    return []
+    
+    try:
+        logger.debug(f"EntryID {entry_id}: Processing search page HTML ({len(html_bytes)} bytes).")
+        
+        # Decode bytes to string, assuming UTF-8 encoding
+        html_content = html_bytes.decode('utf-8', errors='ignore')
+        
+        # Parse HTML with BeautifulSoup
+        soup = BeautifulSoup(html_content, 'html.parser')
+        
+        # Initialize results list
+        results = []
+        
+        # Find search result containers (based on common Google search result structure)
+        # Note: Google’s structure may change; this targets common classes as of 2025
+        result_divs = soup.find_all('div', class_='tF2Cxc')  # Common class for main results
+        
+        for idx, result in enumerate(result_divs):
+            try:
+                # Extract title
+                title_tag = result.find('h3')
+                title = title_tag.get_text(strip=True) if title_tag else "N/A"
+                
+                # Extract URL
+                link_tag = result.find('a')
+                url = link_tag.get('href') if link_tag else "placeholder://no-url"
+                
+                # Extract snippet/description
+                snippet_tag = result.find('div', class_='VwiC3b')  # Common class for snippets
+                snippet = snippet_tag.get_text(strip=True) if snippet_tag else "N/A"
+                
+                # Extract thumbnail URL if available
+                thumbnail_tag = result.find('img')
+                thumbnail_url = thumbnail_tag.get('src') if thumbnail_tag else url
+                
+                # Structure the result
+                result_data = {
+                    "EntryID": entry_id,
+                    "Title": title,
+                    "Url": url,
+                    "Description": snippet,
+                    "ThumbnailUrl": thumbnail_url
+                }
+                
+                results.append(result_data)
+                
+                logger.debug(f"EntryID {entry_id}: Extracted result {idx + 1} - Title: {title[:50]}...")
+                
+            except Exception as e:
+                logger.warning(f"EntryID {entry_id}: Failed to process result {idx + 1}: {e}")
+                continue
+        
+        logger.info(f"EntryID {entry_id}: Successfully extracted {len(results)} results.")
+        return results
+    
+    except Exception as e:
+        logger.error(f"EntryID {entry_id}: Failed to process search page HTML: {e}", exc_info=True)
+        return []
 

--- a/app/icon_image_lib/google_parser.py
+++ b/app/icon_image_lib/google_parser.py
@@ -190,77 +190,73 @@ def get_original_images(html_bytes, logger=None):
 
 def get_results_page_results(html_bytes, final_urls, final_descriptions, final_sources, final_thumbs, logger=None):
     """Extract additional image data from results page HTML without base64."""
-    logger = logger or logging.getLogger(__name__) # Ensure logger
+    logger = logger or logging.getLogger(__name__)  # Ensure logger
     html_content = decode_html_bytes(html_bytes, logger)
 
     soup = BeautifulSoup(html_content, 'html.parser')
-    # Class names for Google search results can change, verify these if issues arise
-    result_divs = soup.find_all('div', class_='H8Rx8c') # This class seems to be for "Related images" or similar blocks
+    # Updated class names based on current Google image search structure (as of 2025)
+    # 'isv-r' and 'tF2Cxc'-like classes are common for image results; using broader selectors
+    result_divs = soup.find_all('div', class_=lambda c: c and any(cls in c for cls in ['isv-r', 'tF2Cxc', 'MjjYud']))  # Added 'MjjYud' as a common container class
 
     if not result_divs:
-        # Try another common class for image result items if H8Rx8c fails
-        result_divs = soup.find_all('div', class_='isv motiva_DRHBO') # Example: for individual image results
+        # Fallback: Try finding 'a' tags with image-related classes or generic result containers
+        result_divs = soup.find_all('a', class_=lambda c: c and 'isv-r' in c) or soup.find_all('div', class_='g')  # 'g' is a fallback for generic result divs
         if not result_divs:
-            result_divs = soup.find_all('a', class_='isv-r') # Another common pattern for image items
-            if not result_divs:
-                 logger.warning("No primary result item divs (H8Rx8c, isv motiva_DRHBO, isv-r) found in additional results page")
-                 return final_urls, final_descriptions, final_sources, final_thumbs
+            logger.warning("No primary result item divs (isv-r, tF2Cxc, MjjYud, g) found in additional results page")
+            return final_urls, final_descriptions, final_sources, final_thumbs
 
     logger.info(f"Found {len(result_divs)} potential items in additional results page.")
 
     for item_container in result_divs:
-        if len(final_urls) >= 100: # Overall cap
+        if len(final_urls) >= 100:  # Overall cap
             break
 
         # Thumbnail
-        # Common img tags: 'rg_i Q4LuWd', 'n3VNCb KAlRDb', 'YQ4gaf'
-        img_tag = item_container.find('img', class_=lambda c: c and any(cls in c for cls in ['rg_i', 'n3VNCb', 'YQ4gaf', 'gdOPf', 'uhHOwf', 'ez24Df']))
+        # Updated image classes: 'YQ4gaf', 'n3VNCb', 'rg_i' are common; added 'sImg' as a potential new class
+        img_tag = item_container.find('img', class_=lambda c: c and any(cls in c for cls in ['YQ4gaf', 'n3VNCb', 'rg_i', 'sImg', 'uhHOwf', 'ez24Df']))
         raw_thumb_url = None
         if img_tag:
-            raw_thumb_url = img_tag.get('src') or img_tag.get('data-src')
-        
-        if not raw_thumb_url or 'data:image' in raw_thumb_url: # Skip base64
+            raw_thumb_url = img_tag.get('src') or img_tag.get('data-src') or img_tag.get('data-lazy-src')  # Added 'data-lazy-src' for modern lazy-loading
+
+        if not raw_thumb_url or 'data:image' in raw_thumb_url:  # Skip base64
             logger.debug("No valid thumbnail URL or base64 src in result item, skipping.")
             continue
-        
-        thumb = clean_source_url(raw_thumb_url) # uXXXX decode for thumb
-        # Thumbnails are usually direct, no need for extract_true_url_from_wrapper or clean_image_url
+
+        thumb = clean_source_url(raw_thumb_url)  # uXXXX decode for thumb
         final_thumbs.append(thumb)
 
         # Description
-        # Common description/title holders: 'bytUYc', 'VFACy kGQAp S2WUTe', 'mVDVAe'
-        desc_element = item_container.find(['div', 'span', 'a'], class_=lambda c: c and any(cls in c for cls in ['bytUYc', 'VFACy', 'mVDVAe', 'VwiC3b']))
+        # Updated description classes: 'VwiC3b' (from process_search_page), 's3v9rd', 'bytUYc'
+        desc_element = item_container.find(['div', 'span', 'a'], class_=lambda c: c and any(cls in c for cls in ['VwiC3b', 's3v9rd', 'bytUYc', 'mVDVAe']))
         description = desc_element.get_text(strip=True) if desc_element else 'No description'
         final_descriptions.append(description)
 
-        # Source (often the domain name or page title linking to the source page)
-        # Common source holders: 'VuuXrf', 'SW5pqf', 'cite' with class 'qLRx3b'
-        source_element = item_container.find(['cite', 'div', 'span'], class_=lambda c: c and any(cls in c for cls in ['VuuXrf', 'SW5pqf', 'qLRx3b']))
+        # Source
+        # Updated source classes: 'VuuXrf', 'qLRx3b', 'iUh30' (common for citations)
+        source_element = item_container.find(['cite', 'div', 'span'], class_=lambda c: c and any(cls in c for cls in ['VuuXrf', 'qLRx3b', 'iUh30']))
         raw_source_text = source_element.get_text(strip=True) if source_element else 'No source'
-        
-        # Process source text: clean uXXXX, then extract if it's a wrapper URL
-        # Check if it looks like a URL before trying to extract from wrapper
+
+        # Process source text
         cleaned_source_text = clean_source_url(raw_source_text)
         if cleaned_source_text.startswith(('http', '/', 'www.')):
             source = extract_true_url_from_wrapper(cleaned_source_text, logger)
         else:
-            source = cleaned_source_text # It's just text, not a URL
+            source = cleaned_source_text  # It's just text, not a URL
         final_sources.append(source)
 
-        # Main Image URL (often found in a link wrapping the image or a data attribute)
-        # Common link tags: 'ایش zReHs', 'VFACy kGQAp S2WUTe', 'isv-r' (if item_container is this)
-        # Sometimes the link is the item_container itself if it's an <a> tag
+        # Main Image URL
+        # Updated link classes: 'VFACy', 'zReHs', or item_container itself if it's an 'a' tag
         link_tag = None
         if item_container.name == 'a':
             link_tag = item_container
         else:
-            link_tag = item_container.find('a', class_=lambda c: c and any(cls in c for cls in ['zReHs', 'VFACy', 'isv-r']))
+            link_tag = item_container.find('a', class_=lambda c: c and any(cls in c for cls in ['VFACy', 'zReHs', 'isv-r']))
 
         raw_href = link_tag.get('href') if link_tag and link_tag.get('href') else None
-        
-        # Alternative: Look for data-actualn3r (or similar) on img_tag for direct full image URL
+
+        # Alternative: Check data attributes for direct image URL
         if not raw_href and img_tag:
-             raw_href = img_tag.get('data-actualn3r') # This sometimes holds the direct image link
+            raw_href = img_tag.get('data-iurl') or img_tag.get('data-actualn3r')  # Added 'data-iurl' as a modern attribute
 
         image_url_final = 'No image URL'
         if raw_href:
@@ -269,7 +265,7 @@ def get_results_page_results(html_bytes, final_urls, final_descriptions, final_s
             image_url_final = clean_image_url(url2)
         final_urls.append(image_url_final)
 
-    if len(final_urls) > 100: # Cap after processing
+    if len(final_urls) > 100:  # Cap after processing
         final_urls = final_urls[:100]
         final_descriptions = final_descriptions[:100]
         final_sources = final_sources[:100]

--- a/app/icon_image_lib/search_page_parser.py
+++ b/app/icon_image_lib/search_page_parser.py
@@ -1,0 +1,85 @@
+import logging
+from typing import List, Tuple
+from urllib.parse import urlparse
+
+from bs4 import BeautifulSoup
+
+from icon_image_lib.google_parser import (
+    clean_image_url,
+    clean_source_url,
+    extract_true_url_from_wrapper,
+)
+
+
+def get_results_page_results(html_bytes: bytes, logger: logging.Logger | None = None) -> Tuple[List[str], List[str], List[str], List[str]]:
+    """Extract organic search results from Google search results HTML.
+
+    Args:
+        html_bytes: Raw HTML bytes of the Google search results page.
+        logger: Optional logger instance for debugging.
+
+    Returns:
+        Tuple of (urls, titles, sources, thumbnails) as lists.
+    """
+    logger = logger or logging.getLogger(__name__)
+    try:
+        html_content = html_bytes.decode("utf-8", errors="ignore")
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.error(f"Failed to decode HTML bytes: {exc}")
+        return [], [], [], []
+
+    soup = BeautifulSoup(html_content, "html.parser")
+    final_urls: List[str] = []
+    final_titles: List[str] = []
+    final_sources: List[str] = []
+    final_thumbs: List[str] = []
+
+    result_divs = soup.find_all("div", class_="MjjYud")
+    if not result_divs:
+        logger.warning("No primary result divs (MjjYud) found, trying alternative selectors")
+        result_divs = soup.find_all("div", class_=lambda c: c and any(cls in c for cls in ["g", "tF2Cxc"]))
+
+    logger.info(f"Found {len(result_divs)} potential result items.")
+
+    for item_container in result_divs:
+        if len(final_urls) >= 100:
+            logger.debug("Reached result cap of 100, stopping.")
+            break
+
+        link_tag = item_container.find("a", href=True)
+        raw_href = link_tag.get("href") if link_tag else None
+        url = extract_true_url_from_wrapper(raw_href, logger) if raw_href else "No URL"
+        final_urls.append(url)
+
+        title_tag = item_container.find("h3")
+        title = title_tag.get_text(strip=True) if title_tag else "No title"
+        final_titles.append(title)
+
+        source_tag = item_container.find("cite")
+        source = (
+            source_tag.get_text(strip=True).split(" › ")[0]
+            if source_tag
+            else urlparse(url).netloc or "No source"
+        )
+        final_sources.append(clean_source_url(source))
+
+        img_tag = item_container.find(
+            "img",
+            class_=lambda c: c and any(cls in c for cls in ["rg_i", "n3VNCb", "YQ4gaf"]),
+        )
+        thumb_url = img_tag.get("src") or img_tag.get("data-src") if img_tag else None
+        thumb = (
+            clean_image_url(thumb_url)
+            if thumb_url and "data:image" not in thumb_url
+            else "No thumbnail"
+        )
+        final_thumbs.append(thumb)
+
+    logger.debug(
+        "Parsed %d results: URLs=%d, Titles=%d, Sources=%d, Thumbnails=%d",
+        len(final_urls),
+        len(final_titles),
+        len(final_sources),
+        len(final_thumbs),
+    )
+    return final_urls, final_titles, final_sources, final_thumbs


### PR DESCRIPTION
## Summary
- add parser to extract organic search results from Google search pages
- filter search results using brand and term keywords and fetch each filtered page

## Testing
- `python -m py_compile app/icon_image_lib/search_page_parser.py app/api.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68912baf4c8c83288572cd379793d76e