### PR TITLE
Parse and filter Google search results

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -55,7 +55,8 @@ from db_utils import (enqueue_db_update, fetch_last_valid_entry,
                       update_file_location_complete, update_initial_sort_order,
                       update_log_url_in_db)
 from email_utils import send_message_email, send_email
-from icon_image_lib.google_parser import process_search_result, process_search_page
+from icon_image_lib.google_parser import process_search_result
+from icon_image_lib.search_page_parser import get_results_page_results
 from logging_config import setup_job_logger
 from rabbitmq_producer import RabbitMQProducer
 from s3_utils import upload_file_to_space
@@ -367,8 +368,31 @@ class SearchClient:
                                                     search_page_json = await search_page_response.json()
                                                     search_page_html = search_page_json.get("result")
                                                     if search_page_html:
-                                                        search_html_bytes = search_page_html.encode('utf-8') if isinstance(search_page_html, str) else str(search_page_html).encode('utf-8')
-                                                        process_search_page(search_html_bytes, entry_id, self.logger)
+                                                        search_html_bytes = (
+                                                            search_page_html.encode("utf-8")
+                                                            if isinstance(search_page_html, str)
+                                                            else str(search_page_html).encode("utf-8")
+                                                        )
+                                                        urls, titles, sources, thumbs = get_results_page_results(
+                                                            search_html_bytes, self.logger
+                                                        )
+                                                        keywords = [brand, term]
+                                                        filtered_results = []
+                                                        for u, t, s, th in zip(urls, titles, sources, thumbs):
+                                                            combined = f"{u} {t}".lower()
+                                                            if all(
+                                                                k.lower() in combined for k in keywords if k
+                                                            ):
+                                                                try:
+                                                                    async with current_session.get(u) as nav_resp:
+                                                                        nav_resp.raise_for_status()
+                                                                        await nav_resp.text()
+                                                                except Exception as nav_e:
+                                                                    self.logger.warning(
+                                                                        f"PID {process_info.pid}: Failed to navigate to {u} for term='{term}' in region {region_name} via {fallback_proxy_type.value}: {nav_e}",
+                                                                        exc_info=True,
+                                                                    )
+                                                                filtered_results.append((u, t, s, th))
                                             except Exception as e_search:
                                                 self.logger.warning(
                                                     f"PID {process_info.pid}: Failed to fetch search page for term='{term}' in region {region_name} via {fallback_proxy_type.value}: {e_search}",
@@ -422,8 +446,29 @@ class SearchClient:
                                         search_page_json = await search_page_response.json()
                                         search_page_html = search_page_json.get("result")
                                         if search_page_html:
-                                            search_html_bytes = search_page_html.encode('utf-8') if isinstance(search_page_html, str) else str(search_page_html).encode('utf-8')
-                                            process_search_page(search_html_bytes, entry_id, self.logger)
+                                            search_html_bytes = (
+                                                search_page_html.encode("utf-8")
+                                                if isinstance(search_page_html, str)
+                                                else str(search_page_html).encode("utf-8")
+                                            )
+                                            urls, titles, sources, thumbs = get_results_page_results(
+                                                search_html_bytes, self.logger
+                                            )
+                                            keywords = [brand, term]
+                                            filtered_results = []
+                                            for u, t, s, th in zip(urls, titles, sources, thumbs):
+                                                combined = f"{u} {t}".lower()
+                                                if all(k.lower() in combined for k in keywords if k):
+                                                    try:
+                                                        async with current_session.get(u) as nav_resp:
+                                                            nav_resp.raise_for_status()
+                                                            await nav_resp.text()
+                                                    except Exception as nav_e:
+                                                        self.logger.warning(
+                                                            f"PID {process_info.pid}: Failed to navigate to {u} for term='{term}' in region {region_name} via {proxy_type.value}: {nav_e}",
+                                                            exc_info=True,
+                                                        )
+                                                    filtered_results.append((u, t, s, th))
                                 except Exception as e_search:
                                     self.logger.warning(
                                         f"PID {process_info.pid}: Failed to fetch search page for term='{term}' in region {region_name} via {proxy_type.value}: {e_search}",

--- a/app/icon_image_lib/google_parser.py
+++ b/app/icon_image_lib/google_parser.py
@@ -81,6 +81,9 @@ from bs4 import BeautifulSoup
 import logging
 import pandas as pd
 import urllib.parse # Added for the new function
+from icon_image_lib.search_page_parser import (
+    get_results_page_results as parse_search_page_results,
+)
 
 # Assuming LR class is in icon_image_lib.LR; otherwise, include it directly here
 from icon_image_lib.LR import LR # Make sure this import works
@@ -322,11 +325,41 @@ def process_search_result(image_html_bytes, entry_id: int, logger=None) -> pd.Da
     return df
 
 def process_search_page(html_bytes, entry_id: int, logger=None):
-    """Placeholder for processing standard Google search HTML results."""
+    """Parse a standard Google search results page into structured data.
+
+    Args:
+        html_bytes: Raw HTML bytes of a Google results page.
+        entry_id: Identifier for logging context.
+        logger: Optional logger instance.
+
+    Returns:
+        List of dictionaries containing Url, Title, Source, and Thumbnail.
+    """
+
     logger = logger or logging.getLogger(__name__)
     if not html_bytes:
         logger.debug(f"EntryID {entry_id}: No search page HTML to process.")
         return []
-    logger.debug(f"EntryID {entry_id}: Received search page HTML ({len(html_bytes)} bytes).")
-    return []
+
+    logger.debug(
+        f"EntryID {entry_id}: Processing search page HTML ({len(html_bytes)} bytes)."
+    )
+
+    try:
+        urls, titles, sources, thumbs = parse_search_page_results(html_bytes, logger)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.error(
+            f"EntryID {entry_id}: Failed to parse search page HTML: {exc}",
+            exc_info=True,
+        )
+        return []
+
+    results = [
+        {"EntryID": entry_id, "Url": u, "Title": t, "Source": s, "Thumbnail": th}
+        for u, t, s, th in zip(urls, titles, sources, thumbs)
+    ]
+    logger.info(
+        f"EntryID {entry_id}: Parsed {len(results)} search results from search page."
+    )
+    return results
 

--- a/app/icon_image_lib/search_page_parser.py
+++ b/app/icon_image_lib/search_page_parser.py
@@ -1,0 +1,85 @@
+import logging
+from typing import List, Tuple
+from urllib.parse import urlparse
+
+from bs4 import BeautifulSoup
+
+from icon_image_lib.google_parser import (
+    clean_image_url,
+    clean_source_url,
+    extract_true_url_from_wrapper,
+)
+
+
+def get_results_page_results(html_bytes: bytes, logger: logging.Logger | None = None) -> Tuple[List[str], List[str], List[str], List[str]]:
+    """Extract organic search results from Google search results HTML.
+
+    Args:
+        html_bytes: Raw HTML bytes of the Google search results page.
+        logger: Optional logger instance for debugging.
+
+    Returns:
+        Tuple of (urls, titles, sources, thumbnails) as lists.
+    """
+    logger = logger or logging.getLogger(__name__)
+    try:
+        html_content = html_bytes.decode("utf-8", errors="ignore")
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.error(f"Failed to decode HTML bytes: {exc}")
+        return [], [], [], []
+
+    soup = BeautifulSoup(html_content, "html.parser")
+    final_urls: List[str] = []
+    final_titles: List[str] = []
+    final_sources: List[str] = []
+    final_thumbs: List[str] = []
+
+    result_divs = soup.find_all("div", class_="MjjYud")
+    if not result_divs:
+        logger.warning("No primary result divs (MjjYud) found, trying alternative selectors")
+        result_divs = soup.find_all("div", class_=lambda c: c and any(cls in c for cls in ["g", "tF2Cxc"]))
+
+    logger.info(f"Found {len(result_divs)} potential result items.")
+
+    for item_container in result_divs:
+        if len(final_urls) >= 100:
+            logger.debug("Reached result cap of 100, stopping.")
+            break
+
+        link_tag = item_container.find("a", href=True)
+        raw_href = link_tag.get("href") if link_tag else None
+        url = extract_true_url_from_wrapper(raw_href, logger) if raw_href else "No URL"
+        final_urls.append(url)
+
+        title_tag = item_container.find("h3")
+        title = title_tag.get_text(strip=True) if title_tag else "No title"
+        final_titles.append(title)
+
+        source_tag = item_container.find("cite")
+        source = (
+            source_tag.get_text(strip=True).split(" › ")[0]
+            if source_tag
+            else urlparse(url).netloc or "No source"
+        )
+        final_sources.append(clean_source_url(source))
+
+        img_tag = item_container.find(
+            "img",
+            class_=lambda c: c and any(cls in c for cls in ["rg_i", "n3VNCb", "YQ4gaf"]),
+        )
+        thumb_url = img_tag.get("src") or img_tag.get("data-src") if img_tag else None
+        thumb = (
+            clean_image_url(thumb_url)
+            if thumb_url and "data:image" not in thumb_url
+            else "No thumbnail"
+        )
+        final_thumbs.append(thumb)
+
+    logger.debug(
+        "Parsed %d results: URLs=%d, Titles=%d, Sources=%d, Thumbnails=%d",
+        len(final_urls),
+        len(final_titles),
+        len(final_sources),
+        len(final_thumbs),
+    )
+    return final_urls, final_titles, final_sources, final_thumbs


### PR DESCRIPTION
## Summary
- add parser to extract organic search results from Google search pages
- filter search results using brand and term keywords and fetch each filtered page
- parse standard search pages into structured results for downstream processing

## Testing
- `python -m py_compile app/icon_image_lib/search_page_parser.py app/api.py app/icon_image_lib/google_parser.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68912baf4c8c83288572cd379793d76e